### PR TITLE
Fix for Python 3.14

### DIFF
--- a/nuclear/cli/parser/value.py
+++ b/nuclear/cli/parser/value.py
@@ -1,6 +1,6 @@
 import inspect
 from collections.abc import Iterable
-from typing import List, Any, Optional
+from typing import List, Any, Optional, get_origin, Union
 
 from nuclear.cli.builder.rule import ValueRule
 from nuclear.cli.builder.typedef import TypeOrParser
@@ -17,13 +17,12 @@ def parse_typed_value(_type: TypeOrParser, arg: str) -> Any:
         return arg
     if _type == bool:
         return boolean(arg)
-    _type_name = str(_type)
-    if _type_name.startswith('typing.Union['):
+    if get_origin(_type) is Union:
         try:
             return _parse_union_value(_type, arg)
         except _TypeNotMatched:
             raise CliSyntaxError(f"variable '{arg}' didn't match Union type: {_type}")
-    elif _type_name.startswith('typing.'):
+    elif type(_type).__module__ == "typing":
         return arg
     # invoke custom parser or cast to custom type
     return _type(arg)


### PR DESCRIPTION
Before:

```
___________________________ test_union_type_param ____________________________
tests/builder/test_typing_parameters.py:31: in test_union_type_param
    cli.run()
nuclear/cli/builder/builder.py:87: in run
    self.run_with_args(sys.argv[1:])
nuclear/cli/builder/builder.py:92: in run_with_args
    parser.parse_args(args)
nuclear/cli/parser/parser.py:84: in parse_args
    run_context: Optional[RunContext] = self._parse_args_queue(args)
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
nuclear/cli/parser/parser.py:99: in _parse_args_queue
    self._parse_subcommand(args) or \
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
nuclear/cli/parser/parser.py:206: in _parse_subcommand
    return subparser._parse_args_queue(args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
nuclear/cli/parser/parser.py:95: in _parse_args_queue
    self._parse_params(args)
nuclear/cli/parser/parser.py:155: in _parse_params
    self._parse_param(rule, value)
nuclear/cli/parser/parser.py:159: in _parse_param
    parsed_value = parse_value_rule(rule, value_str)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
nuclear/cli/parser/value.py:12: in parse_value_rule
    return parse_typed_value(rule.type, arg)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
nuclear/cli/parser/value.py:29: in parse_typed_value
    return _type(arg)
           ^^^^^^^^^^
E   TypeError: 'typing.Union' object is not callable
```

Per https://docs.python.org/3/library/typing.html

Changed in version 3.14: [types.UnionType](https://docs.python.org/3/library/types.html#types.UnionType) is now an alias for Union, and both Union[int, str] and int | str create instances of the same class. To check whether an object is a Union at runtime, use isinstance(obj, Union). For compatibility with earlier versions of Python, use get_origin(obj) is typing.Union or get_origin(obj) is types.UnionType.